### PR TITLE
Fixed issue opening hyperlink in some specific case (see description)

### DIFF
--- a/Code/Blumind/ChartControls/MindMap/MindMapView/MindMapView.cs
+++ b/Code/Blumind/ChartControls/MindMap/MindMapView/MindMapView.cs
@@ -668,7 +668,7 @@ namespace Blumind.Controls.MapViews
             UpdateView(ChangeTypes.AllVisual);
         }
 
-        public void OpenSelectedUrl()
+        public void OpenSelectedUrl(string documentLocation)
         {
             if (Selection.Count > 0)
             {
@@ -683,7 +683,7 @@ namespace Blumind.Controls.MapViews
 
                 foreach (string url in urls)
                 {
-                    Helper.OpenUrl(url);
+                    Helper.OpenUrl(url, documentLocation);
                 }
             }
         }

--- a/Code/Blumind/Controls/ChartPageViews/MindMapChartPage.cs
+++ b/Code/Blumind/Controls/ChartPageViews/MindMapChartPage.cs
@@ -605,7 +605,7 @@ namespace Blumind.ChartPageView
 
         void MenuOpenHyperlink_Click(object sender, EventArgs e)
         {
-            mindMapView1.OpenSelectedUrl();
+            mindMapView1.OpenSelectedUrl((ParentForm as DocumentForm)?.Document.FileName);
         }
 
         void MenuAddTopic_Click(object sender, EventArgs e)

--- a/Code/Blumind/Core/Helper.cs
+++ b/Code/Blumind/Core/Helper.cs
@@ -19,7 +19,7 @@ namespace Blumind
             return (short)value;
         }
 
-        public static void OpenUrl(string url)
+        public static void OpenUrl(string url, string documentLocation = null)
         {
             if (!string.IsNullOrEmpty(url))
             {
@@ -28,7 +28,16 @@ namespace Blumind
                     if (File.Exists(url) && StringComparer.OrdinalIgnoreCase.Equals(Path.GetExtension(url), Document.Extension))
                         Program.MainForm.OpenDocument(url);
                     else
+                    {
+                        if (!string.IsNullOrEmpty(documentLocation))
+                        {
+                            var relativePath = Path.Combine(Path.GetDirectoryName(documentLocation), url);
+
+                            if (!File.Exists(url) && File.Exists(relativePath))
+                                url = relativePath;
+                        }
                         Process.Start(url);
+                    }
                 }
                 catch (System.Exception ex)
                 {


### PR DESCRIPTION
Added ability to open hyperlink of file with url relative to bmd file When file is opened via saved tab

(It was working when a document was open by user but when a document was opened by **last open file loader** it didn't work)